### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,26 +1,13 @@
 {
   "targetDefaults": {
-    "build": {
-      "dependsOn": ["^build"],
-      "cache": true
-    },
-    "test": {
-      "cache": true
-    },
-    "lint": {
-      "cache": true
-    },
-    "@nx/eslint:lint": {
-      "cache": true,
-      "inputs": ["default", "{workspaceRoot}/tools/eslint-rules/**/*"]
-    }
+    "build": { "dependsOn": ["^build"], "cache": true },
+    "test": { "cache": true },
+    "lint": { "cache": true },
+    "@nx/eslint:lint": { "cache": true, "inputs": ["default", "{workspaceRoot}/tools/eslint-rules/**/*"] }
   },
   "extends": "@nx/workspace/presets/npm.json",
   "release": {
-    "changelog": {
-      "workspaceChangelog": false,
-      "projectChangelogs": true
-    },
+    "changelog": { "workspaceChangelog": false, "projectChangelogs": true },
     "projectsRelationship": "independent",
     "conventionalCommits": true,
     "groups": {
@@ -36,11 +23,7 @@
           "@novu/ws"
         ],
         "projectsRelationship": "independent",
-        "version": {
-          "generatorOptions": {
-            "preserveLocalDependencyProtocols": true
-          }
-        }
+        "version": { "generatorOptions": { "preserveLocalDependencyProtocols": true } }
       },
       "packages": {
         "projects": [
@@ -58,27 +41,19 @@
           "@novu/stateless"
         ],
         "projectsRelationship": "independent",
-        "version": {
-          "generatorOptions": {
-            "preserveLocalDependencyProtocols": true
-          }
-        }
+        "version": { "generatorOptions": { "preserveLocalDependencyProtocols": true } }
       }
     }
   },
   "tasksRunnerOptions": {
     "default": {
-      "options": {
-        "canTrackAnalytics": false,
-        "nxCloudId": "61d98cffc3343830d132e541"
-      },
+      "options": { "canTrackAnalytics": false, "nxCloudId": "61d98cffc3343830d132e541" },
       "runner": "nx-cloud"
     }
   },
   "useInferencePlugins": false,
   "defaultBase": "main",
   "useLegacyCache": true,
-  "generatorOptions": {
-    "preserveLocalDependencyProtocols": true
-  }
+  "generatorOptions": { "preserveLocalDependencyProtocols": true },
+  "nxCloudId": "67d8745387c5f14dd23f39d4"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/67d87438bccb868e9e716700/workspaces/67d8745387c5f14dd23f39d4

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.